### PR TITLE
Fix: missing paragraph line in bookmark

### DIFF
--- a/lua/ink/ui/bookmarks.lua
+++ b/lua/ink/ui/bookmarks.lua
@@ -177,6 +177,7 @@ function M.add_bookmark()
         book_title = ctx.data.title,
         book_author = ctx.data.author,
         chapter = ctx.current_chapter_idx,
+        paragraph_line = paragraph_line,
         paragraph_text = paragraph_text,
         context_before = context_before,
         context_after = context_after,


### PR DESCRIPTION
The `paragraph_line` attribute was missing from the bookmark object, which led to errors when performing comparisons with `nil` values in the `get_by_book` function in `bookmarks/query.lua`. This issue prevented multiple bookmarks from being added to the same chapter. This pull request resolves the issue by adding the missing attribute.
